### PR TITLE
Create .secrets.baseline. Ran Detect Secret

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,430 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2022-09-12T21:16:45Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "93fcbf4c3221f6e6fc21e07ec6e87ad94e60bd26",
+        "is_verified": false,
+        "line_number": 194,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2d0822d1228defca104df627a6bd0055ed2ddd0c",
+        "is_verified": false,
+        "line_number": 245,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "example_cycle_qsc_test.go": [
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "example_cycle_test.go": [
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "example_qsc_test.go": [
+      {
+        "hashed_secret": "e80b5f30389f2162470fe780e27b90146e5fb0ca",
+        "is_verified": false,
+        "line_number": 100,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "75d5cc62475c1ed3db14215d819514749ae25f53",
+        "is_verified": false,
+        "line_number": 192,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "example_test.go": [
+      {
+        "hashed_secret": "e80b5f30389f2162470fe780e27b90146e5fb0ca",
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "75d5cc62475c1ed3db14215d819514749ae25f53",
+        "is_verified": false,
+        "line_number": 161,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "go.sum": [
+      {
+        "hashed_secret": "224fa2aa9d9bc6bcb032d31cbafe70aa9c30e4e7",
+        "is_verified": false,
+        "line_number": 1,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3910f51977818b92ecea8ffa8b13da56b58ba8c3",
+        "is_verified": false,
+        "line_number": 2,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ea7940299a53e0c7db33fd4ee102f83d459d54d1",
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e7d2b52449737744aa82f66895db6409dd7efc89",
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4dbbe18874344f8a812138c0c9b17841a5fab11d",
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a1a8a5e0eb58de033e1642fc200f2de46b8d8bd2",
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1959a795aa93723114b9d0624eb25146709b50a0",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "59342e5ed8492010a448b24926fd1d5487524dd9",
+        "is_verified": false,
+        "line_number": 11,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa18cc84565465dca871aa0285736fa8f1c2db75",
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ddd04086256b6596d5678dc919e1018bc7baed6f",
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "84d721026fb8491115d90eb3fe8d30cf71cfea4f",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "408f026f7bf9ac4f0644b90cabd113a3e79c605b",
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5ef8d1522babc7853854a878beb9ba64a670b301",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d77d97e3ba6af0155f27c0a287298176d5aa6099",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8fc907ce9f13c99db5ddb4f2cc806d0381eed01f",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f172edcb9a4ff88d4921555c969d75f1ad980dfb",
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bb33ab9838536d2db0b18a72c5c28a0f941213de",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2b9f5352265bd0b6dc6922eedb405d027930eb9b",
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6a4a1948d9e9978e41ee2d466928b91e8ac5d54b",
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c382813ad978b45fb54312f408087e014b4374eb",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4c8bd1746d2bc964f4467b301809ca67016388ee",
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f16e20544c05634663c76b999b6707da9f0ecbcc",
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8d19507fdd8eb2c703e7fea913f2df6ca08b5491",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6befd736c9d2fdf056c960bb1469537e0588cda6",
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3765eda8e7c792ffa4b4cfca6385122b32fcb9e0",
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "63b7f6287b07502e4febcc3eed0275062f3d96f6",
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "22141383e8b029b6781684a4126ec0254bfea003",
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "iam/iam.go": [
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3e4bdbe0b80e63c22b178576e906810777387b50",
+        "is_verified": false,
+        "line_number": 120,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "integration_test.go": [
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "kp_qsc_test.go": [
+      {
+        "hashed_secret": "11634ea6495b17ca913d24b49dca32b40e491dc0",
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "kp_test.go": [
+      {
+        "hashed_secret": "11634ea6495b17ca913d24b49dca32b40e491dc0",
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9f4ed0cc38e03da4c3caf3d8500e0af69cfaefd3",
+        "is_verified": false,
+        "line_number": 157,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3e48fe9928e96dde5f50bd5514ccaecc504e378e",
+        "is_verified": false,
+        "line_number": 597,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1db2bd37f8f782671869552e73459e8a32150068",
+        "is_verified": false,
+        "line_number": 1438,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0599eac7c4ebc38a9fb5407c1cee19877850ff78",
+        "is_verified": false,
+        "line_number": 1475,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7056dab9fea569e2fcb5122c763bfe90d3fa8204",
+        "is_verified": false,
+        "line_number": 1476,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "policy.go": [
+      {
+        "hashed_secret": "6a361a4e087eab69b48211aecc712bdc3403b2eb",
+        "is_verified": false,
+        "line_number": 290,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.50.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
Team,
As part of “3Q2022: FS-IA readiness”, all the repositories must enable “Detect Secrets” tool [detect secrets](https://w3.ibm.com/w3publisher/detect-secrets), also scan and audit the secrets in their repositories before **9/18/2022**.

In this PR I’ve enabled “detect-secrets” and also scanned this repository. The results are in file `.secrets.baseline`. 

I request that the team audit the potential secrets discovered in this scan.

## Action to take by any contributor of this repo before merging 

 - [ ] Locally, install [detect secret](https://w3.ibm.com/w3publisher/detect-secrets)
 - [ ] Pull this branch
 - [ ] Run detect secret audit on the secrets
 - [ ] Push results to repo

The setup should be quick. The audit itself will take only a few minutes on each repo or maybe 10 minutes on a very large repo.


Installation of secret detect is quick, but there is also a docker method available if you have docker desktop that takes no setup ([Using docker to run detect secrets](https://github.ibm.com/Whitewater/whitewater-detect-secrets/wiki/Developer-Tool-FAQs#docker-setup)).

For further info on detect-secrets please visit: https://w3.ibm.com/w3publisher/detect-secrets/developer-tool
Thanks

Signed-off-by: Henry Grantham <hgrantham@gmail.com>

